### PR TITLE
Fix incorrect verbose solution

### DIFF
--- a/server.js
+++ b/server.js
@@ -60,8 +60,8 @@ function gateKeeper(req, res, next) {
   // ^^ the more verbose way to express this is:
   //
   // const parsedHeader = queryString.parse(req.get('x-username-and-password'));
-  // const user = queryString.user || null;
-  // const pass = queryString.pass || null;
+  // const user = parsedHeader.user || null;
+  // const pass = parsedHeader.pass || null;
 
   // if there's a user in `USERS` with the username
   // and password from the request headers,


### PR DESCRIPTION
The previous solution used `queryString.user` and `queryString.pass` to access the header contents which is incorrect. Since the parsed header contents are present in `parsedHeader`, we should use `parsedHeader.user` and `parsedHeader.pass`.